### PR TITLE
Wait for input to be enabled to avoid iframe load race conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,8 @@ describe('payment form', () => {
 ## Development
 
 To modify this plugin, `git clone` the repo and run `yarn install`. You can run
-the tests with `yarn test`.
+the tests with `yarn test` after setting the environment variables `CYPRESS_TEST_APP_PORT` and `STRIPE_PUBLISHABLE_KEY`:
+
+```
+CYPRESS_TEST_APP_PORT=4000 STRIPE_PUBLISHABLE_KEY=your_key_here yarn test
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,14 @@ Cypress.Commands.add('fillElementsInput', (field: CypressStripeElementsFieldName
     .should(iframe => expect(iframe.contents().find(selector)).to.exist)
     .then(iframe => cy.wrap(iframe.contents().find(selector)))
     .within(input => {
-      cy.wrap(input).type(value);
+      /**
+       * The .should("not.be.disabled") check implements a Cypress-team-recommended
+       * workaround for cases where the iframe isn't completely loaded,
+       * so Cypress fails on the type() command because the input is
+       * temporarily disabled.
+       * 
+       * See https://github.com/cypress-io/cypress/issues/5827#issuecomment-751995883
+       */
+      cy.wrap(input).should("not.be.disabled").type(value);
     });
 })


### PR DESCRIPTION
Per discussion in #4 , updates the library to wait for Stripe input elements to be enabled before entering the type command. Also updates the README to note the environment variables that must be set when running tests.